### PR TITLE
Remove providers from Terraform package.

### DIFF
--- a/chalice/package.py
+++ b/chalice/package.py
@@ -799,12 +799,12 @@ class TerraformGenerator(TemplateGenerator):
         template = {
             'resource': {},
             'terraform': {
-                'required_version': '> 0.11.0, < 1.1.0'
-            },
-            'provider': {
-                'template': {'version': '~> 2'},
-                'aws': {'version': '>= 2, < 4'},
-                'null': {'version': '>= 2, < 4'},
+                'required_version': '> 0.11.0, < 1.1.0',
+                'required_providers': {
+                    'aws': {'version': '>= 2, < 4'},
+                    'template': {'version': '~> 2'},
+                    'null': {'version': '>= 2, < 4'}
+                }
             },
             'data': {
                 'aws_caller_identity': {'chalice': {}},


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/chalice/issues/1717

*Description of changes:*
As the issues specifies, providers in this format have been deprecated, and do not work correctly in 1.0 (it is not possible to pass in default provider settings while these are specified).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
